### PR TITLE
Update terminology on developer.altvr.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Content for https://developer.altvr.com/
 - `scripts/`
 	Installation, build and deploy scripts.
 
+## Local Testing and Development
+
+See: https://help.github.com/en/articles/setting-up-your-github-pages-site-locally-with-jekyll#step-2-install-jekyll-using-bundler
+
 ## Deployment
 The site is automatically deployed by Travis-CI (https://travis-ci.org/AltspaceVR/AltspaceSDK-site) when you push to
 `master`.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,8 +83,8 @@
             </section>
             <hr/>
             <em class="fineprint">
-                &copy; {{ site.time | date: "%Y" }} by AltspaceVR, Inc.
-                AltspaceVR&reg; and altvr&trade; are trademarks of AltspaceVR, Inc.
+                &copy; {{ site.time | date: "%Y" }} by Microsoft.
+                AltspaceVR&reg; and altvr&trade; are trademarks of Microsoft.
             </em><br/>
             <span class="fineprint">
                 All other trademarks are the property of their respective owners. All rights reserved.

--- a/pages/404.md
+++ b/pages/404.md
@@ -4,7 +4,7 @@ permalink: /404.html
 <h1 class="centered">Page Not Found!</h1>
 
 <p class="centered">
-Are we missing something? Let us know on <a href="/slack">the Community Slack</a>.
+Are we missing something? Let us know on <a href="/discord">the MRE SDK discord community</a>.
 <figure>
 <img src="/assets/images/icecreamdrop.png" />
 </figure>

--- a/pages/building-altspacevr-apps-with-a-frame.md
+++ b/pages/building-altspacevr-apps-with-a-frame.md
@@ -14,9 +14,9 @@ in with the [A-Frame Documentation](https://aframe.io/docs/0.3.0/introduction/).
 component to your `<a-scene>` tag. Keep in mind though that development in AltspaceVR has a few
 [caveats](https://github.com/altspacevr/altspacesdk#graphics-feature-support).
 
-In either case, you should join the [AltspaceVR SDK Slack channel](/slack)! We love to see what you’re working on, and
+In either case, you should join the [MRE SDK Discord community](/discord)! We love to see what you’re working on, and
 are always happy to answer questions. In addition, there are special activities available only for developers that may
-be better for apps. Just request developer status on Slack, and we’ll hook you up!
+be better for apps. Just request developer status on the [MRE SDK Discord community](/discord), and we’ll hook you up!
 
 ## What is A-Frame?
 
@@ -212,7 +212,6 @@ down to 2500, so that it doesn’t conflict with the more distant default skybox
 So that’s it! You should now know how to set up your very own simple AltspaceVR app with A-Frame. If you want to keep
 learning, we recommend you look at these [A-Frame examples](https://altspacevr.github.io/aframe/examples/) in-game, find
 one that interests you, and examine its source code. If you’re looking for specific information, again, look us up on
-[Slack](https://altspacevr-slackin.herokuapp.com/), and we’ll walk
-you through whatever difficulty you’re having.
+the [MRE SDK Discord community](/discord), and we’ll walk you through whatever difficulty you’re having.
 
 See you on the other side!

--- a/pages/index.md
+++ b/pages/index.md
@@ -31,7 +31,7 @@ permalink: /
     construction of holographic, multi-user web apps and experiences for virtual reality.
     The MRE SDK can be used together with Worlds items and custom glTF models to create a variety of
     content that can be experienced with consumer VR hardware like the Oculus Rift or HTC Vive,
-    as well as mobile headsets like the Oculus Go and Google Daydream.</p>
+    as well as mobile headsets such as the Oculus Go.</p>
 
     <p>New to AltspaceVR? <a href="https://account.altvr.com/users/sign_up">Create an account</a></p>
 

--- a/pages/local-dev.md
+++ b/pages/local-dev.md
@@ -66,4 +66,4 @@ created a [starter project](https://github.com/AltspaceVR/altspace-webpack-start
 3. If you are using a different web server, configure it to use http://localhost:7878 so that you don’t need to change
     the enclosure URL every time.
 4. Have fun and remember that you can always ask questions in our
-    [Slack chat group](/slack).
+    [MRE SDK Discord community](/discord).

--- a/redirects/discord.md
+++ b/redirects/discord.md
@@ -1,0 +1,7 @@
+---
+layout: redirect
+permalink: discord/
+redirect:
+    to: https://discord.gg/ypvBkWz
+    message: the MRE SDK Discord community
+---

--- a/redirects/slack.md
+++ b/redirects/slack.md
@@ -1,7 +1,0 @@
----
-layout: redirect
-permalink: slack/
-redirect:
-    to: http://sdk-slackin.altvr.com/
-    message: the AltspaceVR SDK Slack
----


### PR DESCRIPTION
## Overview of Changes

* Remove references to "Daydream"
* Replace references to "AltspaceVR, Inc." with "Microsoft"
* Replace references to Slack with MRE Discord
* Removed Slack redirect
* Added a link in the readme for local dev/test setup

## Manual Testing

### 404 page:

![image](https://user-images.githubusercontent.com/52220496/65281025-76160a80-dae6-11e9-8ac8-f6ac4b86d298.png)

### Discord redirect:

![image](https://user-images.githubusercontent.com/52220496/65281086-95ad3300-dae6-11e9-9e9a-9698197b669d.png)

### AltspaceVR, Inc. -> Microsoft replacement:

![image](https://user-images.githubusercontent.com/52220496/65281163-cab98580-dae6-11e9-956a-b05dd44e2ebc.png)

### Slack -> Discord:

![image](https://user-images.githubusercontent.com/52220496/65281346-3dc2fc00-dae7-11e9-9d8e-7537ed4142c4.png)

![image](https://user-images.githubusercontent.com/52220496/65281372-516e6280-dae7-11e9-8e0a-26fe7b2f7ea9.png)