### PR TITLE
Force footer to bottom of page

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -3,6 +3,10 @@
 
 @import "{{ site.theme }}";
 
+html {
+    display: flex;
+}
+
 body {
     font-family: "Helvetica Neue",Helvetica,Helvetica,Arial,sans-serif;
     padding: 0;
@@ -10,6 +14,7 @@ body {
     display: flex;
     min-height: 100vh;
     flex-direction: column;    
+    width: 100%;    
 }
 
 $varela: "Varela Round", sans-serif;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -6,7 +6,10 @@
 body {
     font-family: "Helvetica Neue",Helvetica,Helvetica,Arial,sans-serif;
     padding: 0;
-    margin: 0;
+    margin: 0;    
+    display: flex;
+    min-height: 100vh;
+    flex-direction: column;    
 }
 
 $varela: "Varela Round", sans-serif;
@@ -132,6 +135,8 @@ aside {
 }
 
 div.wrapper {
+    // IE 11 support - '0 auto' prevents footer from being stuck at top of page
+    flex: 1 0 auto; 
     width: 1000px;
     padding: 0.4em;
     @media print, screen and (max-width: 960px) {


### PR DESCRIPTION
## Bug

Observed footer floating above bottom of screen on short pages:

![image](https://user-images.githubusercontent.com/52220496/65291382-fbf67d80-db07-11e9-9bed-8e95d50efaee.png)

Reproducable naturally on large monitors, or by using the zoom functionality of the browser to shrink the page.

## Overview of Changes

Updated body and div.wrapper CSS (the main content blocks on this site) to force footer to the bottom of the page.

### Troubleshooting sources

* https://philipwalton.github.io/solved-by-flexbox/demos/sticky-footer/
* https://gist.github.com/palicko/26b327cd2198e52c25b13485b4dd02bc - Html flex and body width 100% enabled this fix in IE 11
* https://stackoverflow.com/questions/31835164/how-do-i-fix-a-flexbox-sticky-footer-in-ie11 - This prevents the footer from sticking to the top of the page in IE 11

## Manual Testing

![image](https://user-images.githubusercontent.com/52220496/65291427-2cd6b280-db08-11e9-9d23-41deb070b479.png)

Verified in the following browsers:

* Chrome, Version 76.0.3809.132 (Official Build) (64-bit)
* Firefox Quantum, 69.0.1 (64-bit)
* Microsoft Edge 44.18362.329.0
* IE 11.356.18362.0
