### PR TITLE
Footer - Add Community Standards, split into 2 columns

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -73,6 +73,7 @@
                     <li><a href="https://altvr.com/contact/">Contact Us</a></li>
                     <li><a href="https://aka.ms/privacy">Privacy Policy</a></li>
                     <li><a href="https://altvr.com/terms-of-service/">Terms of Service</a></li>
+                    <li><a href="https://altvr.com/standards/">Community Standards</a></li>
                 </ol>
                 <ol class="social">
                     <li><a href="https://twitter.com/altspacevr"><i class="fab fa-twitter fa-lg"></i></a></li>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -108,6 +108,17 @@ footer {
     .links {
         font-size: 9pt;
         margin: 0 1em;
+        -webkit-columns: 2;
+        -moz-columns: 2;
+        columns: 2;
+        padding-left: 0;      
+
+        li {
+            list-style-position: inside;
+            -webkit-column-break-inside: avoid;
+            page-break-inside: avoid;
+            break-inside: avoid;
+        }        
     }
 
     .social {


### PR DESCRIPTION
## Overview of Changes

* Added 'Community Standards' link to footer: https://altvr.com/standards/
* Split footer links into two columns

## Manual Testing

Tested in Chrome, FF, Edge, IE 11, Altspace browser.

In Altspace:

![image](https://user-images.githubusercontent.com/52220496/66612854-39cf4a80-eb78-11e9-9f81-6194ad5220d3.png)
