### PR TITLE
Unity Upgrade - Upgrade instructions following client release

### DIFF
--- a/pages/upgrade-2019-2.md
+++ b/pages/upgrade-2019-2.md
@@ -34,6 +34,5 @@ If you have a kit or template project in Unity 2018.1, follow these instructions
 6. Wait while Unity upgrades all your assets and meta files.
 7. If you get any "blank errors" in the console after you import your project, you may be hitting a Unity bug. To fix this, close Unity, open the file `C:\Program Files\Unity\Hub\Editor\2019.2.12f1\Editor\Data\Tools\RoslynScripts\unity_csc.bat` in a text editor, change "csc" to "csc.exe" in line 3, and save. Reopen Unity, and the error should be gone.
 8. Build your asset bundles like normal for kits or templates.
-9. If you are uploading your bundles via the website, make sure to select "2019" in the Zip Unity Version field.
 
 Congratulations, you've updated your project to Unity 2019.2!


### PR DESCRIPTION
## Overview of Changes

Upgrade instructions following client release.  Changes:

* Removed step #9 to select "2019" in the zip unity version field. This field will be hidden on the website following the client release.